### PR TITLE
Ignore clangd files, ignore any "build*/" directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,13 @@
 .vs/
 cmake-build-debug/
 bin/
-build/
+build*/
 out/
 slgj
 _deps/
 CMakeFiles/
 CMakeSettings.json
+
+# clangd stuff
+.cache/
+compile_commands.json


### PR DESCRIPTION
This PR adds clangd files to .gitignore, as well as change the "build/" ignore to "build*/".
The build ignore is useful if you build for desktop separated from web, like using "build" for desktop builds and "build-web" for web builds in the same workspace.