### PR TITLE
Add raylib as a Git submodule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ insert_final_newline = true
 [*.{c,h}]
 indent_style = space
 indent_size = 2
+
+[CMake*.txt]
+indent_style = space
+indent_size = 2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/raylib"]
+	path = libs/raylib
+	url = https://github.com/raysan5/raylib.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,23 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 project(slgj C)
 set(CMAKE_C_STANDARD 99)
 
-# the `pkg_check_modules` function is created with this call
-find_package(PkgConfig REQUIRED)
-
-# Adding Raylib
-include(FetchContent)
-set(FETCHCONTENT_QUIET FALSE)
-set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE) # don't build the supplied examples
-set(BUILD_GAMES    OFF CACHE BOOL "" FORCE) # don't build the supplied example games
-
-FetchContent_Declare(
-  raylib
-  GIT_REPOSITORY "https://github.com/raysan5/raylib.git"
-  GIT_TAG "master"
-  GIT_PROGRESS TRUE
-)
-
-FetchContent_MakeAvailable(raylib)
+# Third party libs (currently only raylib)
+add_subdirectory(libs)
 
 # Adding our source files
 file(GLOB_RECURSE PROJECT_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/sources/*.c") # Define PROJECT_SOURCES as a list of all source files

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(BUILD_SHARED_LIBS OFF)  # link third party libraries statically
+
+# raylib
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/raylib")
+  message(FATAL_ERROR "Could not find raylib folder. Did you clone the Git submodules?")
+endif()
+
+add_subdirectory(raylib)
+target_compile_options(raylib PRIVATE "-w")  # disable warnings


### PR DESCRIPTION
This way, there is only one folder for raylib and we don't need to clone it every time we configure a CMake build in a new folder. Also, it should make it easier to automatically generate s7 to C binding code using raylib parser.
This PR also disables raylib's compilation warnings.

Note: I don't know if "libs" is the best name for this folder, maybe "3rdparty" would be a nice one as well (or it may doesn't matter at all).
Also, maybe it makes sense moving s7 to this folder, since it's a third-party library as well.